### PR TITLE
Advanced feature testing

### DIFF
--- a/server/events/eventStream.ts
+++ b/server/events/eventStream.ts
@@ -9,6 +9,8 @@ type StreamInfo = {
   lastEventAt: Date | null;
 };
 
+type EventHandler = (event: BaseEvent) => void | Promise<void>;
+
 /**
  * Lightweight in-memory event stream implementation used to satisfy
  * server-side real-time APIs within this repository. The goal is to
@@ -18,6 +20,7 @@ type StreamInfo = {
 export class EventStreamService {
   private static instance: EventStreamService;
   private events: Map<string, StoredEvent[]> = new Map();
+  private subscribers: Map<string, Set<EventHandler>> = new Map();
 
   private constructor() {}
 
@@ -51,6 +54,16 @@ export class EventStreamService {
       bucket.splice(0, bucket.length - 10_000);
     }
 
+    // Fan out to subscribers for this category (best-effort; don't block publishing)
+    const subs = this.subscribers.get(key);
+    if (subs && subs.size > 0) {
+      await Promise.allSettled(
+        Array.from(subs).map(async (handler) => {
+          await handler(storeEvent);
+        })
+      );
+    }
+
     return storeEvent.id;
   }
 
@@ -76,7 +89,7 @@ export class EventStreamService {
 
     return bucket
       .filter((event) => {
-        const ts = event.timestamp;
+        const ts = event.timestamp ?? event.created_at;
         return ts >= startTime && ts <= endTime;
       })
       .slice(-limit);
@@ -93,8 +106,28 @@ export class EventStreamService {
     return {
       category,
       totalEvents: bucket.length,
-      firstEventAt: first ? first.timestamp : null,
-      lastEventAt: last ? last.timestamp : null,
+      firstEventAt: first ? (first.timestamp ?? first.created_at) : null,
+      lastEventAt: last ? (last.timestamp ?? last.created_at) : null,
+    };
+  }
+
+  /**
+   * Subscribe to a category stream.
+   * Returns an unsubscribe function.
+   */
+  public async subscribe(category: string, handler: EventHandler): Promise<() => void> {
+    if (!this.subscribers.has(category)) {
+      this.subscribers.set(category, new Set());
+    }
+    this.subscribers.get(category)!.add(handler);
+
+    return () => {
+      const set = this.subscribers.get(category);
+      if (!set) return;
+      set.delete(handler);
+      if (set.size === 0) {
+        this.subscribers.delete(category);
+      }
     };
   }
 
@@ -103,5 +136,6 @@ export class EventStreamService {
    */
   public async destroy(): Promise<void> {
     this.events.clear();
+    this.subscribers.clear();
   }
 }

--- a/server/events/notificationService.ts
+++ b/server/events/notificationService.ts
@@ -91,7 +91,14 @@ export class NotificationService {
     this.eventStream = EventStreamService.getInstance();
     this.wsGateway = WebSocketGateway.getInstance();
     const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
-    this.redis = new Redis(redisUrl);
+    // Use lazyConnect so we can attach error handlers before connecting.
+    this.redis = new Redis(redisUrl, { lazyConnect: true });
+    this.redis.on('error', (error) => {
+      console.warn('[NotificationService] Redis error:', error?.message || error);
+    });
+    this.redis.connect().catch((error) => {
+      console.warn('[NotificationService] Redis connect failed:', error?.message || error);
+    });
     
     this.setupDefaultAlertRules();
     this.setupDigestProcessing();

--- a/server/stripe-marketplace.ts
+++ b/server/stripe-marketplace.ts
@@ -492,4 +492,14 @@ export class StripeMarketplaceService {
   }
 }
 
-export const stripeMarketplace = new StripeMarketplaceService();
+let stripeMarketplaceSingleton: StripeMarketplaceService | null = null;
+
+/**
+ * Lazily instantiate Stripe so missing Stripe config doesn't prevent the server
+ * from starting (non-marketplace endpoints should still work).
+ */
+export function getStripeMarketplace(): StripeMarketplaceService {
+  if (stripeMarketplaceSingleton) return stripeMarketplaceSingleton;
+  stripeMarketplaceSingleton = new StripeMarketplaceService();
+  return stripeMarketplaceSingleton;
+}


### PR DESCRIPTION
Fixes critical server boot blockers by implementing `EventStreamService.subscribe`, lazy-initializing Stripe, and resolving an `express` reference error to enable application startup.

The server was unable to start due to several issues identified during QA: `NotificationService` expected a `subscribe` method on `EventStreamService` that was missing, `StripeMarketplaceService` and `SubscriptionService` eagerly initialized Stripe causing crashes without `STRIPE_SECRET_KEY`, and `routes.ts` had an undefined `express` reference. These changes are essential to allow the application to boot and proceed with runtime testing of advanced features.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae51a160-c192-43dd-96b8-ca32e41b9062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae51a160-c192-43dd-96b8-ca32e41b9062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables server startup stability and real-time fanout.
> 
> - **Event stream**: Adds `subscribe(category, handler)` with best-effort async fanout; maintains subscriber map; includes timestamp fallback (`timestamp ?? created_at`) in range queries and stream info; clears subscribers on `destroy()`.
> - **Notifications**: Makes Redis connection lazy with error handlers to avoid boot blocking.
> - **Stripe marketplace**: Introduces `getStripeMarketplace()` singleton; updates routes to use it for products/prices/checkout/webhooks/analytics/refunds/fees.
> - **Subscriptions**: Lazily instantiates Stripe in `SubscriptionService` via `getStripe()`; all Stripe calls routed through it; clearer errors when unset.
> - **Routes**: Fixes `express` import; subscription webhook uses `express.raw`; general wiring updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 390dcbd3484156115482db18c0df4f2cedf8313b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->