### PR TITLE
Hostinger mcp server config

### DIFF
--- a/.cursor/mcp.sample.json
+++ b/.cursor/mcp.sample.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "hostinger-mcp": {
+      "command": "npx",
+      "args": ["hostinger-api-mcp@latest"],
+      "env": {
+        "API_TOKEN": "<SET_HOSTINGER_API_TOKEN_HERE>"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vite.config.ts.*
 # Environment
 .env.local
 .env.*.local
+
+# Cursor MCP (keep real tokens out of git)
+.cursor/mcp.json


### PR DESCRIPTION
Add a sample `hostinger-mcp` configuration and update `.gitignore` to prevent committing sensitive MCP server tokens.

This PR provides a safe, committed sample configuration for the `hostinger-mcp` server, while ensuring that the actual configuration containing sensitive API tokens remains local and is not accidentally committed to the repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f3886cf-ebcf-4353-bc82-1e0e53ce5628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f3886cf-ebcf-4353-bc82-1e0e53ce5628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a safe sample configuration for the Hostinger MCP server and tightens ignore rules to prevent committing secrets.
> 
> - Adds `.cursor/mcp.sample.json` with `hostinger-mcp` setup using `npx hostinger-api-mcp@latest` and placeholder `API_TOKEN`
> - Updates `.gitignore` to include `.cursor/mcp.json` and ensure `*.env.*.local` files are ignored
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b345cfd008c49495ef648f340b8c5931c979e76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->