### PR TITLE
Membership onboarding improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build:vercel": "PUPPETEER_SKIP_DOWNLOAD=true vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --minify",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "db:push": "drizzle-kit push",
     "vercel-build": "npm run build:vercel"
   },
@@ -134,11 +136,15 @@
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.31.4",
     "esbuild": "^0.26.0",
+    "jsdom": "^26.0.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "terser": "^5.44.1",
     "tsx": "^4.20.5",
     "typescript": "5.6.3",
+    "vitest": "^3.1.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "vite": "^5.4.21"
   },
   "optionalDependencies": {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,9 @@
+import "@testing-library/jest-dom/vitest";
+
+// Some components/tests stub fetch directly; keep a safe default.
+if (!(globalThis as any).fetch) {
+  (globalThis as any).fetch = async () => {
+    throw new Error("global fetch is not mocked for this test");
+  };
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,4 +71,13 @@ export default defineConfig({
       deny: ["**/.*"],
     },
   },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./tests/setup.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
+    exclude: ["tests/e2e-*.test.ts"],
+    clearMocks: true,
+    restoreMocks: true,
+  },
 });


### PR DESCRIPTION
Set up Vitest and React Testing Library to make the existing test suite runnable and enable comprehensive UI testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-5988dbfd-5530-4edc-aad4-cc5b26d71ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5988dbfd-5530-4edc-aad4-cc5b26d71ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes a runnable unit testing setup using Vitest with a jsdom environment and React Testing Library.
> 
> - Adds Vitest config in `vite.config.ts` (`test` block: `environment: "jsdom"`, `globals`, `setupFiles`, targeted `include`/`exclude`, `clearMocks`/`restoreMocks`).
> - Introduces `tests/setup.ts` to load `@testing-library/jest-dom` and provide a default `fetch` stub.
> - Adds npm scripts `test` and `test:watch` in `package.json` and dev deps: `vitest`, `jsdom`, `@testing-library/*`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ab2bbfa6b7521ca14564f3852253258c8039244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->