### PR TITLE
Fix Vercel detection and remove duplicate animation constants

### DIFF
--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -84,16 +84,6 @@ const slideInRight = {
   visible: { opacity: 1, x: 0, transition: { duration: 0.7, ease: "easeOut" } },
 };
 
-const slideInLeft = {
-  hidden: { opacity: 0, x: -60 },
-  visible: { opacity: 1, x: 0, transition: { duration: 0.8, ease: "easeOut" } }
-};
-
-const slideInRight = {
-  hidden: { opacity: 0, x: 60 },
-  visible: { opacity: 1, x: 0, transition: { duration: 0.8, ease: "easeOut" } }
-};
-
 // Floating animation for decorative elements
 const float = {
   animate: {

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
+  "framework": null,
   "buildCommand": "npm run build:vercel",
   "installCommand": "PUPPETEER_SKIP_DOWNLOAD=true npm install",
   "outputDirectory": "dist/public",


### PR DESCRIPTION
### Motivation
- Vercel was auto-detecting a Next.js project which caused the deploy step to attempt `next build` and fail with “No Next.js version detected”.
- The local production build was also blocked by duplicate symbol declarations for animation variants in the landing page, causing `esbuild` failures during the Vite build.

### Description
- Added `"framework": null` to `vercel.json` to disable framework auto-detection and ensure the custom `buildCommand` (`npm run build:vercel`) is used.
- Removed duplicate `slideInLeft` and `slideInRight` constant declarations from `client/src/pages/landing.tsx` so the module no longer has duplicate symbol errors.
- Kept the original animation variants used by the page and preserved other animation definitions to avoid changing runtime behavior.

### Testing
- Ran the production build with `npm run build:vercel`, which completed successfully and produced the expected outputs including `dist/public` and `dist/index.js`.
- The Vite/esbuild production build finished without the previous duplicate-symbol error and assets were emitted as part of the build (build completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a33149ef6c832487233b90149316e1)