### PR TITLE
Wire Vercel app into GitHub deployment workflow

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,96 @@
+name: Vercel Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment (Preview)
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build project artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy preview
+        id: deploy_preview
+        run: |
+          preview_url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `✅ Preview deployed to: ${{ steps.deploy_preview.outputs.preview_url }}`;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment (Production)
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build project artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -56,6 +56,31 @@ Configure the following environment variables in your Vercel project settings:
 4. Configure environment variables in the project settings
 5. Deploy
 
+
+## GitHub Actions + Vercel App Workflow (Recommended)
+
+This repo now includes `.github/workflows/vercel-deploy.yml` to connect GitHub events directly to your Vercel project.
+
+### What it does
+
+- Pull requests: builds and deploys a **Preview** deployment, then comments the URL back on the PR.
+- Pushes to `main`: builds and deploys **Production**.
+- `workflow_dispatch`: allows manual runs from the Actions tab.
+
+### One-time setup
+
+1. In Vercel, install the **Vercel for GitHub** app (if not already installed) and link this repository.
+2. In the Vercel project, open **Settings → General** and copy:
+   - `Project ID` → save as `VERCEL_PROJECT_ID` in GitHub repo secrets
+   - `Team ID` or account/org ID → save as `VERCEL_ORG_ID`
+3. In Vercel, create a personal token (or team token) with deploy access and save in GitHub repo secrets as `VERCEL_TOKEN`.
+4. In GitHub, go to **Settings → Secrets and variables → Actions** and add:
+   - `VERCEL_TOKEN`
+   - `VERCEL_ORG_ID`
+   - `VERCEL_PROJECT_ID`
+
+After this, every PR should automatically receive a preview URL comment from the workflow.
+
 ## Build Configuration
 
 The project includes optimized build settings in `vercel.json`:


### PR DESCRIPTION
### Motivation
- Provide an automated CI/CD connection between GitHub and Vercel so pull requests get preview deployments and pushes to `main` produce production deployments.
- Make it easy for maintainers to enable Vercel deploys from GitHub Actions and document the minimal secret setup required.

### Description
- Added a new GitHub Actions workflow at `.github/workflows/vercel-deploy.yml` that runs Preview deployments for PRs and Production deployments for pushes to `main` and supports `workflow_dispatch` manual runs.
- The workflow uses the Vercel CLI (`vercel pull`, `vercel build`, `vercel deploy --prebuilt`) and sets concurrency to cancel in-progress runs for the same ref.
- The workflow posts the preview URL back to the PR using `actions/github-script` so reviewers can access the preview quickly.
- Updated `VERCEL_DEPLOYMENT.md` with a new **GitHub Actions + Vercel App Workflow (Recommended)** section describing one-time setup and required repository secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID`.

### Testing
- Ran `git diff --check` to validate whitespace/formatting and it completed without issues.
- Ran `npm run check` (TypeScript typecheck) which failed due to pre-existing TypeScript errors unrelated to the workflow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecb9324c60832495c1c95dd9d53ba7)